### PR TITLE
feat(doc-plugin): add websocket HTML and Adoc generation mojos

### DIFF
--- a/src/main/java/com/ly/doc/plugin/constant/MojoConstants.java
+++ b/src/main/java/com/ly/doc/plugin/constant/MojoConstants.java
@@ -112,6 +112,16 @@ public interface MojoConstants {
     String WEBSOCKET_MARKDOWN_MOJO = "websocket-markdown";
 
     /**
+     * websocket html.
+     */
+    String WEBSOCKET_HTML_MOJO = "websocket-html";
+
+    /**
+     * websocket adoc.
+     */
+    String WEBSOCKET_ADOC_MOJO = "websocket-adoc";
+
+    /**
      * grpc markdown.
      */
     String GRPC_MARKDOWN_MOJO = "grpc-markdown";

--- a/src/main/java/com/ly/doc/plugin/mojo/WebSocketAdocMojo.java
+++ b/src/main/java/com/ly/doc/plugin/mojo/WebSocketAdocMojo.java
@@ -22,7 +22,7 @@
  */
 package com.ly.doc.plugin.mojo;
 
-import com.ly.doc.builder.websocket.WebSocketMarkdownBuilder;
+import com.ly.doc.builder.websocket.WebSocketAsciidocBuilder;
 import com.ly.doc.model.ApiConfig;
 import com.ly.doc.plugin.constant.MojoConstants;
 import com.thoughtworks.qdox.JavaProjectBuilder;
@@ -34,19 +34,19 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * websocket Markdown
+ * websocket-adoc
  *
  * @author linwumingshi
- * @since 3.0.3
+ * @since 3.0.7
  */
 @Execute(phase = LifecyclePhase.COMPILE)
-@Mojo(name = MojoConstants.WEBSOCKET_MARKDOWN_MOJO, requiresDependencyResolution = ResolutionScope.COMPILE)
-public class WebSocketMarkdownMojo extends BaseDocsGeneratorMojo {
+@Mojo(name = MojoConstants.WEBSOCKET_ADOC_MOJO, requiresDependencyResolution = ResolutionScope.COMPILE)
+public class WebSocketAdocMojo extends BaseDocsGeneratorMojo {
 
     @Override
     public void executeMojo(ApiConfig apiConfig, JavaProjectBuilder javaProjectBuilder) throws MojoExecutionException, MojoFailureException {
         try {
-            WebSocketMarkdownBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
+            WebSocketAsciidocBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
             if (apiConfig.isStrict()) {

--- a/src/main/java/com/ly/doc/plugin/mojo/WebSocketHtmlMojo.java
+++ b/src/main/java/com/ly/doc/plugin/mojo/WebSocketHtmlMojo.java
@@ -22,7 +22,7 @@
  */
 package com.ly.doc.plugin.mojo;
 
-import com.ly.doc.builder.websocket.WebSocketMarkdownBuilder;
+import com.ly.doc.builder.websocket.WebSocketHtmlBuilder;
 import com.ly.doc.model.ApiConfig;
 import com.ly.doc.plugin.constant.MojoConstants;
 import com.thoughtworks.qdox.JavaProjectBuilder;
@@ -34,19 +34,19 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * websocket Markdown
+ * websocket Html
  *
  * @author linwumingshi
- * @since 3.0.3
+ * @since 3.0.7
  */
 @Execute(phase = LifecyclePhase.COMPILE)
-@Mojo(name = MojoConstants.WEBSOCKET_MARKDOWN_MOJO, requiresDependencyResolution = ResolutionScope.COMPILE)
-public class WebSocketMarkdownMojo extends BaseDocsGeneratorMojo {
+@Mojo(name = MojoConstants.WEBSOCKET_HTML_MOJO, requiresDependencyResolution = ResolutionScope.COMPILE)
+public class WebSocketHtmlMojo extends BaseDocsGeneratorMojo {
 
     @Override
     public void executeMojo(ApiConfig apiConfig, JavaProjectBuilder javaProjectBuilder) throws MojoExecutionException, MojoFailureException {
         try {
-            WebSocketMarkdownBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
+            WebSocketHtmlBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
             if (apiConfig.isStrict()) {


### PR DESCRIPTION
Extend the documentation plugin to support generation of websocket HTML and AsciiDoc (Adoc) formats. This commit introduces two new mojos, `WEBSOCKET_HTML_MOJO` and `WEBSOCKET_ADOC_MOJO`, alongside the existing `WEBSOCKET_MARKDOWN_MOJO`. The plugin now offers a more comprehensive set of options for documentation generation tailored to different preferences and usages.