### PR TITLE
build: Use variable format for smart-doc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ly.smart-doc</groupId>
     <artifactId>smart-doc-maven-plugin</artifactId>
-    <version>3.0.6</version>
+    <version>${smart-doc.version}</version>
     <packaging>maven-plugin</packaging>
 
     <name>smart-doc-maven-plugin</name>
@@ -34,6 +34,7 @@
     </developers>
 
     <properties>
+        <smart-doc.version>3.0.6</smart-doc.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.pluging.version>3.8.6</maven.pluging.version>
         <maven.pluging.annotations.version>3.8.2</maven.pluging.annotations.version>
@@ -72,7 +73,7 @@
         <dependency>
             <groupId>com.ly.smart-doc</groupId>
             <artifactId>smart-doc</artifactId>
-            <version>3.0.6</version>
+            <version>${smart-doc.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
- Add a `smart-doc.version` property to the `pom.xml`.
- The property is set to `${env.smart-doc-version}`, which can be updated using the command:
```shell
mvn versions:set-property -Dproperty=smart-doc.version -DnewVersion="${{ env.smart-doc-version }}" -DgenerateBackupPoms=false
```